### PR TITLE
Fix handling of missing scenario files

### DIFF
--- a/bluesky/stack/stack.py
+++ b/bluesky/stack/stack.py
@@ -1135,6 +1135,10 @@ def ic(filename=''):
     ''' Function implementing the IC stack command. '''
     global scenfile, scenname
 
+    # For our current use-case, we always pass the path relative to BlueSky's root directory
+    if filename and not os.path.exists(filename):
+        return False, "Error: cannot find file: " + filename
+
     # reset sim always
     bs.sim.reset()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,6 @@
 
 # In addition to requirements.txt, the following are required for development and testing
 psutil == 5.5.*
-
-# PyTest 4 is also available, can we upgrade to that?
 pytest == 4.1.*
 pylint == 2.2.*
 pylint-exit == 1.0.*


### PR DESCRIPTION
For our use-case, we need to detect if the scenario file passed to the `IC` command exists _before_ we reset the simulation. This also allows us to return an error to BlueBird, which is reported to clients in the API response.

Note: This breaks BlueSky's 'fuzzy finding' of the requested scenario. The file path and extension must now be fully specified, relative to the BlueSky root directory.