### PR TITLE
Add PyQtWebEngine to fix 'Bluesky needs pyqt5' error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pyqt5
+PyQtWebEngine
 numpy
 scipy
 pandas


### PR DESCRIPTION
Attempting to run in GUI mode was giving the error 'Bluesky needs pyqt5' despite that package already being installed (as confirmed by running check.py). The fix was to [add PyQtWebEngine](https://stackoverflow.com/questions/33108133/how-to-build-qt-webengine-for-pyqt5) to `requirements.txt`.