### PR TITLE
Make bluesky use headless by default when pip installing, have gui option via extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ATM and/or Python to join us. Please feel free to comment, criticise, and contri
 ## Installation on Linux/Mac
 
 Run the install script to create the required Python virtual environment (optionally with the `--headless` flag to omit GUI dependencies for a minimal installation):
-> ./install [--headless]
+> ./install.sh [--headless]
 
 Then follow the instructions at the end of the script.
 
@@ -54,6 +54,27 @@ sudo apt-get install python3-tk
 sudo pip3 install virtualenv
 ```
 then re-run the install script.
+
+## Installation using pip
+
+Note that headless is now the default when installing using pip (in contrast to the `install.sh` method above).
+To install a full GUI environment please do the following:
+
+```bash
+# NOTE: 'full' option attempts to pip install pyopengl-acclerate, which may have issues installing
+python3 -m pip install bluesky-simulator[full] || \
+  python3 -m pip install bluesky-simulator[gui]
+```
+
+If installing in development mode change this to:
+> python3 -m pip install -e .
+
+Note that to install the GUI dependencies in development mode, this becomes:
+
+```bash
+python3 -m pip install -e .[full] || \
+  python3 -m pip install -e .[gui]
+```
 
 ## Docker support
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python3 -m pip install bluesky-simulator[full] || \
   python3 -m pip install bluesky-simulator[gui]
 ```
 
-If installing in development mode change this to:
+If installing in development mode from a locally cloned copy of bluesky (instead of via PyPI) change this to:
 > python3 -m pip install -e .
 
 Note that to install the GUI dependencies in development mode, this becomes:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ python3 -m pip install bluesky-simulator[full] || \
   python3 -m pip install bluesky-simulator[gui]
 ```
 
+The pip install approach above may fail due to permissions if using the system python3.
+Either append `--user` to the pip command above or prepend `sudo` if you are on a Linux/Mac machine.    
+
 If installing in development mode from a locally cloned copy of bluesky (instead of via PyPI) change this to:
 > python3 -m pip install -e .
 

--- a/install.sh
+++ b/install.sh
@@ -34,14 +34,14 @@ eval set -- $args
 
 # Parse the options
 headless=false
-requirements="requirements.txt"
+requirements="requirements-gui.txt"
 venvname="venv"
 while getopts ":he:" opt; do
   case $opt in
     h)
       printf "Headless mode installation\n"
       headless=true
-      requirements="requirements_headless.txt"
+      requirements="requirements.txt"
       ;;
     e)
       printf "Virtual environment name: $OPTARG\n"

--- a/install.sh
+++ b/install.sh
@@ -2,11 +2,11 @@
 
 # Check for python3. 
 # NOTE: Uses `which` as `command` test method fails in certain environments.
-if [[ `which python3  &>/dev/null | wc -l` -gt 0]]; then
+if [[ `which python3 2>/dev/null | wc -l` -gt 0 ]]; then
     printf "Found python3\n"
 else
     printf "Please install python3\n"
-    exit 1
+    # exit 1
 fi
 
 # Check for pip3.

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Check for python3.
-if command -v python3 &>/dev/null; then
+# Check for python3. 
+# NOTE: Uses `which` as `command` test method fails in certain environments.
+if [[ `which python3  &>/dev/null | wc -l` -gt 0]]; then
     printf "Found python3\n"
 else
     printf "Please install python3\n"
@@ -9,7 +10,7 @@ else
 fi
 
 # Check for pip3.
-if command -v pip3 &>/dev/null; then
+if [[ `which python3 -m pip | wc -l` -gt 0 ]]; then
     printf "Found pip3\n"
 else
     printf "Please install python3-pip\n"
@@ -62,14 +63,6 @@ if [ -e $venvname ]; then
     exit 1
 fi
 
-# Check for virtualenv
-if command -v virtualenv &>/dev/null; then
-    printf "Found virtualenv\n"
-else
-    printf "Please install virtualenv\n"
-    exit 1
-fi
-
 # matplotlib imports tkinter
 python3 -c "import tkinter"
 status=$?
@@ -79,15 +72,20 @@ if [[ $status != 0 ]]; then
 fi
 
 # Create a virtual environment.
+# NOTE: Fallback to python3's inbuilt venv if virtualenv fails
 printf "Creating virtual environment: $venvname\n"
-pip3 install --upgrade virtualenv
-virtualenv -p python3 $venvname
+(python3 -m pip install --upgrade virtualenv && \
+  virtualenv -p python3 $venvname) || \
+    (python3 -m venv $venvname) || (
+        printf "Please install virtualenv\n" && \
+        exit 1
+    )
 
 printf "Activating virtual environment\n"
 source $venvname/bin/activate
 
 printf "Installing dependencies\n"
-pip3 install -r $requirements
+python3 -m pip install -r $requirements
 
 status=$?
 if [[ $status != 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ else
 fi
 
 # Check for pip3.
-if [[ `which python3 -m pip | wc -l` -gt 0 ]]; then
+if [[ `python3 -m pip | wc -l` -gt 0 ]]; then
     printf "Found pip3\n"
 else
     printf "Please install python3-pip\n"

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,0 +1,13 @@
+pyqt5
+PyQtWebEngine
+numpy
+scipy
+pandas
+matplotlib
+pyopengl
+# pyopengl-accelerate
+msgpack
+zmq
+pygame
+
+semver == 2.8.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,8 @@
-pyqt5
-PyQtWebEngine
 numpy
 scipy
-pandas
 matplotlib
-pyopengl
-# pyopengl-accelerate
 msgpack
 zmq
-pygame
+pandas
 
 semver == 2.8.*

--- a/requirements_headless.txt
+++ b/requirements_headless.txt
@@ -1,8 +1,0 @@
-numpy
-scipy
-matplotlib
-msgpack
-zmq
-pandas
-
-semver == 2.8.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,37 @@
+[extras]
+# For CLI only bluesky environment
+headless =
+    numpy
+    scipy
+    matplotlib
+    msgpack
+    zmq
+    pandas
+    semver == 2.8.*
+# For GUI bluesky environment
+gui =
+    numpy
+    scipy
+    matplotlib
+    msgpack
+    zmq
+    pandas
+    semver == 2.8.*
+    pyqt5
+    PyQtWebEngine
+    pygame
+    pyopengl
+# NOTE: pyopengl-accelerate is awkward to pip install from PyPI
+full =
+    numpy
+    scipy
+    matplotlib
+    msgpack
+    zmq
+    pandas
+    semver == 2.8.*
+    pyqt5
+    PyQtWebEngine
+    pygame
+    pyopengl
+    pyopengl-accelerate

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,35 +1,16 @@
 [extras]
-# For CLI only bluesky environment
+# For CLI only bluesky environment: pip install bluesky-simulator[headless]
 headless =
-    numpy
-    scipy
-    matplotlib
-    msgpack
-    zmq
-    pandas
-    semver == 2.8.*
-# For GUI bluesky environment
+    # already defined in requirements.txt
+# For GUI bluesky environment: pip install bluesky-simulator[gui]
 gui =
-    numpy
-    scipy
-    matplotlib
-    msgpack
-    zmq
-    pandas
-    semver == 2.8.*
     pyqt5
     PyQtWebEngine
     pygame
     pyopengl
 # NOTE: pyopengl-accelerate is awkward to pip install from PyPI
+# For accelerated GUI bluesky environment: pip install bluesky-simulator[full]
 full =
-    numpy
-    scipy
-    matplotlib
-    msgpack
-    zmq
-    pandas
-    semver == 2.8.*
     pyqt5
     PyQtWebEngine
     pygame

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from os import path
 from setuptools import setup, find_packages
 from codecs import open
 import glob
+import configparser
 
 here = path.abspath(path.dirname(__file__))
 
@@ -10,9 +11,20 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+# get extra requirements from setup.cfg
+parser = configparser.ConfigParser()
+parser.read('%s/setup.cfg' % here)
+extras_requirements = {k: [vi.strip().split('#') for vi in v.split('\n') if vi]
+                       for (k, v) in dict(parser['extras']).items()}
+extras_requirements.update({
+    'dev': ['check-manifest'],
+    'test': ['coverage', 'flake8', 'radon', 'nose'],
+})
+
+
 setup(
     name='bluesky-simulator',  # 'bluesky' package name already taken in PyPI
-    version='0.0.1.dev2',
+    version='0.0.1.dev3',
     description='The Open Air Traffic Simulator',
     long_description=long_description,
     url='https://github.com/ProfHoekstra/bluesky',
@@ -40,10 +52,7 @@ setup(
     keywords='atm transport simulation aviation aircraft',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),  # Required
     install_requires=open(here + '/requirements.txt', 'r').readlines(),
-    extras_require={
-        'dev': ['check-manifest'],
-        'test': ['coverage', 'flake8', 'radon', 'nose'],
-    },
+    extras_require=extras_requirements,
     include_package_data=True,
     package_data={
           'data': [f for f in glob.glob('data/**/*') if path.isfile(f)] + ['data/default.cfg']


### PR DESCRIPTION
This PR modifies the setup configuration of bluesky so that:

- headless mode is the default when pip installing (original `install.sh` behaviour retained)
- option to install PyQt/pygame GUI environment using `[gui]` extra_requires
- option to install GUI environment with `pyopengl-accelerate` (which is a pain installing via pip/PyPI) using `[full]` extra_requires.
- Updated README to install section for pip install approach